### PR TITLE
Fix clippy warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
+
+# Ignore idea
+.idea

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,34 +1,20 @@
-
-use structopt::StructOpt;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(
-    name = "aws ops", 
-    about = "AWS Configure Profile"
-)]
+#[structopt(name = "aws ops", about = "AWS Configure Profile")]
 pub struct Opt {
-
-    #[structopt(
-        short = "r",
-        long = "region",
-        help = "Region Selector"
-    )]
+    #[structopt(short = "r", long = "region", help = "Region Selector")]
     pub region: bool,
     // TODO add explicit profile
     // #[structopt(short = "p", long = "profile")]
     // pub profile: String,
-  
-    #[structopt(
-        short = "v", 
-        long = "version",
-        help = "Print version info and exit"
-    )]
+    #[structopt(short = "v", long = "version", help = "Print version info and exit")]
     pub version: bool,
-    
+
     #[structopt(
-        short = "c", 
-        long = "config", 
+        short = "c",
+        long = "config",
         parse(from_os_str),
         help = "Override an aws configuration file (default = ~/.aws/config)"
     )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,10 +255,12 @@ pub fn parse_credentials_file(
 
         // handle the opening of named profile blocks
         if profile_regex.is_match(&unwrapped_line) {
-            if profile_name.is_some() && access_key.is_some() && secret_key.is_some() {
-                let creds =
-                    AwsCredentials::new(access_key.unwrap(), secret_key.unwrap(), token, None);
-                profiles.insert(profile_name.unwrap(), creds);
+            if let (Some(profile_name_value), Some(access_key_value), Some(secret_key_value)) =
+                (profile_name, access_key, secret_key)
+            {
+                let creds = AwsCredentials::new(access_key_value, secret_key_value, token, None);
+
+                profiles.insert(profile_name_value, creds);
             }
 
             access_key = None;
@@ -301,9 +303,12 @@ pub fn parse_credentials_file(
         }
     }
 
-    if profile_name.is_some() && access_key.is_some() && secret_key.is_some() {
-        let creds = AwsCredentials::new(access_key.unwrap(), secret_key.unwrap(), token, None);
-        profiles.insert(profile_name.unwrap(), creds);
+    if let (Some(profile_name_value), Some(access_key_value), Some(secret_key_value)) =
+    (profile_name, access_key, secret_key)
+    {
+        let creds = AwsCredentials::new(access_key_value, secret_key_value, token, None);
+
+        profiles.insert(profile_name_value, creds);
     }
 
     if profiles.is_empty() {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -174,7 +174,7 @@ fn default_env(env: &str) -> String {
     }
 }
 
-fn to_key_list<'a, K, V>(map: &'a HashMap<K, V>) -> Vec<&'a K> {
+fn to_key_list<K, V>(map: &HashMap<K, V>) -> Vec<&K> {
     let mut key_list = Vec::new();
 
     for key in map.keys() {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -53,10 +53,10 @@ use crate::cmdline::Opt;
 use awsp::{default_config_location, parse_config_file};
 
 use dialoguer::{theme::ColorfulTheme, Select};
-use std::{collections::HashMap, process};
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
+use std::{collections::HashMap, process};
 use sysinfo::{get_current_pid, ProcessExt, Signal, System, SystemExt};
 
 const REGIONS_DISPLAY: &[&str] = &[
@@ -110,10 +110,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 // TODO Error Handler
 // pub fn run(opt: &Opt) -> Result<(), Box<dyn Error>> {
 pub fn run(opt: &Opt) {
-    
     if opt.version {
         print!("\nawsp: ");
-        green_ln!("{}\n",VERSION);
+        green_ln!("{}\n", VERSION);
         process::exit(1);
     } else if opt.region {
         region_menu();
@@ -135,9 +134,9 @@ fn display_selected() {
     print!("{esc}c", esc = 27 as char);
     green!("\n ->");
     print!("  Profile: ");
-    green!("{}",default_env("AWS_PROFILE"));
+    green!("{}", default_env("AWS_PROFILE"));
     print!(" | Region: ");
-    green_ln!("{} \n",default_env("AWS_DEFAULT_REGION"));
+    green_ln!("{} \n", default_env("AWS_DEFAULT_REGION"));
 }
 
 fn profile_menu() {


### PR DESCRIPTION
# Motivation

There're some warning generates from cargo-clippy which is Rust linting. This PR is to clear all of the warnings and make the repo green

# What has been done?

- Fix clippy warning unnecessary_unwrap
- Fix clippy warning needless_lifetimes